### PR TITLE
feat: add sweep as keyboard option

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,4 +47,3 @@ fn find_rc_file(path: &Path) -> Option<PathBuf> {
         }
     }
 }
-

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,3 +47,4 @@ fn find_rc_file(path: &Path) -> Option<PathBuf> {
         }
     }
 }
+

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 mod adv360;
+mod sweep;
 
 #[derive(Serialize, Deserialize)]
 pub enum KeyboardLayoutType {
     #[serde(rename = "kinesis:adv360")]
     Adv360,
+    #[serde(rename = "sweep")]
+    Sweep,
 }
 
 pub struct KeyboardLayout {
@@ -22,5 +25,6 @@ impl KeyboardLayout {
 pub fn get_layout(layout_type: &KeyboardLayoutType) -> KeyboardLayout {
     match layout_type {
         KeyboardLayoutType::Adv360 => adv360::get_layout(),
+        KeyboardLayoutType::Sweep => sweep::get_layout(),
     }
 }

--- a/src/layouts/sweep.rs
+++ b/src/layouts/sweep.rs
@@ -1,0 +1,13 @@
+use super::KeyboardLayout;
+
+pub fn get_layout() -> KeyboardLayout {
+    #[rustfmt::skip]
+    let bindings = vec![
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      0, 0, 0, 1, 1, 1, 1, 0, 0, 0,
+    ];
+
+    return KeyboardLayout { bindings, row_count: 4 };
+}


### PR DESCRIPTION
Adds the Sweep keyboard as an option for formatting

By the way, I noticed that dtsfmt adds a bunch of whitespace on the last line

<img width="1398" alt="image" src="https://github.com/mskelton/dtsfmt/assets/68512346/14374075-3a55-4c61-8691-c4bcf4029853">
