### PR TITLE
Support labels as 'identifiers' and fix tests

### DIFF
--- a/tests/specs/labeled_item.txt
+++ b/tests/specs/labeled_item.txt
@@ -15,3 +15,25 @@ macro_triple_grave: macro_triple_grave {
   bindings = <&kp GRAVE>, <&kp GRAVE>, <&kp GRAVE>;
   hold-while-undecided;
 };
+
+== labels inside nested nodes ==
+/ {
+  label: device {
+    compatible = "label test";
+
+    sublabel: subdevice {
+      maybe-we-have-an-interrupt;
+    };
+  };
+};
+
+[expect]
+/ {
+  label: device {
+    compatible = "label test";
+
+    sublabel: subdevice {
+      maybe-we-have-an-interrupt;
+    };
+  };
+};


### PR DESCRIPTION
Tests appear to be failing because treesitter changed how labels and names were parsed. These are both passed passed as 'identifiers'. This commit adds support for parsing identifiers and makes an attempt to make some of the node and label parsing more generalized.