### PR TITLE
Use nightly toolchain in workflows so format action works

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
 
       - name: Check formatting
-        run: cargo fmt --all --check
+        run: cargo +nightly fmt --all --check

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,10 +1,9 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
 
 use crate::layouts::KeyboardLayoutType;
-use serde::Deserialize;
 
 mod constants;
 

--- a/src/emitter/files.rs
+++ b/src/emitter/files.rs
@@ -1,5 +1,6 @@
-use super::*;
 use std::fs;
+
+use super::*;
 
 #[derive(Debug, Default)]
 pub struct FilesEmitter {}

--- a/src/emitter/mod.rs
+++ b/src/emitter/mod.rs
@@ -1,8 +1,8 @@
-pub use self::files::*;
-pub use self::stdout::*;
-
 use std::io;
 use std::path::PathBuf;
+
+pub use self::files::*;
+pub use self::stdout::*;
 
 mod files;
 mod stdout;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
-use ignore::gitignore::GitignoreBuilder;
-use ignore::{types::TypesBuilder, WalkBuilder};
-use std::path::Path;
-use std::{
-    fs,
-    io::{self, Read},
-    path::PathBuf,
-};
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use dtsfmt::{
-    config::Config,
-    emitter::{create_emitter, Emitter, FormattedFile},
-};
+use dtsfmt::config::Config;
+use dtsfmt::emitter::{create_emitter, Emitter, FormattedFile};
+use ignore::gitignore::GitignoreBuilder;
+use ignore::types::TypesBuilder;
+use ignore::WalkBuilder;
 
 #[derive(PartialEq)]
 enum FormattingStatus {
@@ -183,7 +179,8 @@ fn format(
     emit(emitter, result, &output, &source, check)
 }
 
-/// Emits the output of formatting either in check mode or by writing to the file.
+/// Emits the output of formatting either in check mode or by writing to the
+/// file.
 fn emit(
     emitter: &mut Box<dyn Emitter>,
     result: FormattedFile,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -2,11 +2,16 @@ use std::collections::VecDeque;
 
 use tree_sitter::TreeCursor;
 
-use crate::{
-    context::Context,
-    layouts::{self, KeyboardLayoutType},
-    parser::parse,
-    utils::{get_text, lookahead, lookbehind, pad_right, print_indent, sep},
+use crate::context::Context;
+use crate::layouts::{self, KeyboardLayoutType};
+use crate::parser::parse;
+use crate::utils::{
+    get_text,
+    lookahead,
+    lookbehind,
+    pad_right,
+    print_indent,
+    sep,
 };
 
 fn is_preproc(n: &tree_sitter::Node) -> bool {
@@ -26,7 +31,8 @@ fn traverse(
 
     match node.kind() {
         "comment" => {
-            // Add a newline before the comment if the previous node is not a comment
+            // Add a newline before the comment if the previous node is not a
+            // comment
             if lookbehind(cursor).is_some_and(|n| n.kind() != "comment") {
                 sep(writer);
             }

--- a/src/test_utils/fs.rs
+++ b/src/test_utils/fs.rs
@@ -1,6 +1,7 @@
-use super::*;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use super::*;
 
 pub fn get_specs_in_dir(path: &Path) -> Vec<(PathBuf, Spec)> {
     let mut result: Vec<(PathBuf, Spec)> = Vec::new();

--- a/src/test_utils/spec_helpers.rs
+++ b/src/test_utils/spec_helpers.rs
@@ -1,10 +1,12 @@
+use std::fmt::Display;
+use std::path::Path;
+
 use console::Style;
 use similar::{ChangeTag, TextDiff};
-use std::{fmt::Display, path::Path};
-
-use crate::{layouts::KeyboardLayoutType, printer::print};
 
 use super::get_specs_in_dir;
+use crate::layouts::KeyboardLayoutType;
+use crate::printer::print;
 
 struct FailedTestResult {
     expected: String,

--- a/src/test_utils/spec_parser.rs
+++ b/src/test_utils/spec_parser.rs
@@ -35,7 +35,8 @@ pub fn parse_specs(file_text: String) -> Vec<Spec> {
 
         if !lines.first().unwrap().starts_with(message_separator) {
             panic!(
-                "All spec files should start with a message. (ex. {0} Message {0})",
+                "All spec files should start with a message. (ex. {0} Message \
+                 {0})",
                 message_separator
             );
         }


### PR DESCRIPTION
The configuration in rustfmt.toml appears to rely on features that are not in the stable toolchain, as evidenced by the warnings in the 'check formatting' stage of the Build workflow (ex:
https://github.com/mskelton/dtsfmt/actions/runs/16820506520/job/47646281792). Switching the action to use +nightly gets the workflow back to formating as desired.

Also run a +nightly `cargo fmt` to get everything in sync and see that the workflow completes without warnings.