### PR TITLE
Support/fix unit-address

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -261,6 +261,9 @@ fn traverse(
         }
         // All the non-named grammatical tokens that are emitted but handled
         // simply with some output structure.
+        "@" => {
+            writer.push('@');
+        }
         "}" => {
             print_indent(writer, &ctx.dec(1));
             writer.push('}');

--- a/tests/specs/identifiers.txt
+++ b/tests/specs/identifiers.txt
@@ -1,0 +1,9 @@
+== node with a unit-address and label ==
+label: node@1000 {
+  compatible = "dtsfmt";
+};
+
+[expect]
+label: node@1000 {
+  compatible = "dtsfmt";
+};


### PR DESCRIPTION
All that was needed was to handle the '@' now that identifier parsing has been generalized.