### PR TITLE
Support parsing label and node reference types.

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -160,8 +160,21 @@ fn traverse(
                 writer.push('\n');
             }
         }
-        "identifier" | "string_literal" | "unit_address" => {
+        "identifier" | "string_literal" | "unit_address" | "path" => {
             writer.push_str(get_text(source, cursor));
+        }
+        "reference" => {
+            // A reference has a format of "&label" or "&{path}".
+
+            // Visit all children of the reference without changing the
+            // indentation.
+            if cursor.goto_first_child() {
+                traverse(writer, source, cursor, ctx);
+                while cursor.goto_next_sibling() {
+                    traverse(writer, source, cursor, ctx);
+                }
+                cursor.goto_parent();
+            }
         }
         // This is a general handler for any type that just needs to traverse
         // its children.
@@ -263,6 +276,12 @@ fn traverse(
         // simply with some output structure.
         "@" => {
             writer.push('@');
+        }
+        "&" => {
+            writer.push('&');
+        }
+        "&{" => {
+            writer.push_str("&{");
         }
         "}" => {
             print_indent(writer, &ctx.dec(1));

--- a/tests/specs/references.txt
+++ b/tests/specs/references.txt
@@ -1,0 +1,28 @@
+== label reference is formatted ==
+& node {
+  child {
+    compatible = "node-child";
+  };
+};
+
+[expect]
+&node {
+  child {
+    compatible = "node-child";
+  };
+};
+
+== node reference is formatted ==
+&{ /path/to/node
+} {
+	child {
+    compatible = "node-child";
+  };
+};
+
+[expect]
+&{/path/to/node} {
+  child {
+    compatible = "node-child";
+  };
+};


### PR DESCRIPTION
reference type is defined in tree-sitter-devicetree (node-types [1]
and grammar [2]).

A label reference type is defined as `&label` where `label` is an "identifier" field of the "reference" node.

A node reference type is defined as `&{path}` where `path` is a "path" node.

This adds support to parse a "reference" node with the prefix and suffix symbols printed properly.

Fixes #30 
Test: added tests/specs/references.txt

[1] https://github.com/joelspadin/tree-sitter-devicetree/blob/e685f1f6ac1702b046415efb476444167d63e41a/src/node-types.json#L1586
[2] https://github.com/joelspadin/tree-sitter-devicetree/blob/e685f1f6ac1702b046415efb476444167d63e41a/src/grammar.json#L271