### PR TITLE
Do not add a newline if the comment is at the top of a node.

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -7,12 +7,7 @@ use crate::context::Context;
 use crate::layouts;
 use crate::parser::parse;
 use crate::utils::{
-    get_text,
-    lookahead,
-    lookbehind,
-    pad_right,
-    print_indent,
-    sep,
+    get_text, lookahead, lookbehind, pad_right, print_indent, sep,
 };
 
 fn is_preproc(n: &tree_sitter::Node) -> bool {
@@ -36,8 +31,10 @@ fn traverse(
         }
         "comment" => {
             // Add a newline before the comment if the previous node is not a
-            // comment
-            if lookbehind(cursor).is_some_and(|n| n.kind() != "comment") {
+            // comment nor a '{'.
+            if lookbehind(cursor)
+                .is_some_and(|n| n.kind() != "comment" && n.kind() != "{")
+            {
                 sep(writer);
             }
 

--- a/tests/specs/comments.txt
+++ b/tests/specs/comments.txt
@@ -14,3 +14,41 @@
 [expect]
 // Layers
 #define DEFAULT 0
+
+== comments inside nodes can be formatted ==
+/ {
+  device { // comment1
+    compatible = "device";
+         // comment2
+    property;
+  };
+};
+
+[expect]
+/ {
+  device {
+    // comment1
+    compatible = "device";
+
+    // comment2
+    property;
+  };
+};
+
+== no empty lines between { and comments ==
+/ {
+  device {
+    
+    
+        // comment
+    compatible = "device";
+  };
+};
+
+[expect]
+/ {
+  device {
+    // comment
+    compatible = "device";
+  };
+};


### PR DESCRIPTION
Previously dtsfmt always added a newline before a comment if the previous line was not a comment. This change updates the printer behavior so that it doesn't add a new line if the comment node is the first node after the left curly brace `{`.

Test: added unittest case to comments.txt
Fixes #28
