### PR TITLE
Remove redundant whitespaces for empty comment lines.

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -48,8 +48,13 @@ fn traverse(
             // lot tougher to format properly.
             match comment.starts_with("//") {
                 true => {
-                    writer.push_str("// ");
-                    writer.push_str(comment.trim_start_matches("//").trim());
+                    let trimmed_comment = comment.trim_start_matches("//").trim();
+                    if trimmed_comment.is_empty() {
+                        writer.push_str("//");
+                    } else {
+                        writer.push_str("// ");
+                        writer.push_str(trimmed_comment);
+                    }
                 }
                 false => writer.push_str(comment),
             }

--- a/tests/specs/comments.txt
+++ b/tests/specs/comments.txt
@@ -6,6 +6,22 @@
 // foo
 // bar
 
+== should trim redundant whitespaces ==
+//no prefix/suffix spaces
+//   both prefix and suffix spaces  
+//     prefix spaces only
+//	
+//    	
+//
+
+[expect]
+// no prefix/suffix spaces
+// both prefix and suffix spaces
+// prefix spaces only
+//
+//
+//
+
 == should re-align with code ==
 // Layers
 


### PR DESCRIPTION
If a comment line is empty (with only whitespaces), the output comment line should be `//` instead of `// `.

Test: added a test case to comments.txt
