### PR TITLE
Place a new line between nodes

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -219,6 +219,17 @@ fn traverse(
             {
                 writer.push('\n');
             }
+
+            // Place a newline before node siblings if they follow a node.
+            //
+            // The `n != node` check is to prevent adding a newline before the
+            // last node.
+            if node.kind() == "node"
+                && lookahead(cursor)
+                    .is_some_and(|n| n.kind() == "node" && n != node)
+            {
+                writer.push('\n');
+            }
         }
         "byte_string_literal" => {
             let hex_string = get_text(source, cursor);

--- a/tests/specs/layouts/adv360.txt
+++ b/tests/specs/layouts/adv360.txt
@@ -23,6 +23,7 @@ behaviors { dm: dual_mod_key {
       bindings = <&kp>, <&kp>;
     };
   };
+
   keymap {
     compatible = "zmk,keymap";
 
@@ -66,6 +67,7 @@ behaviors { dm: dual_mod_key {
       bindings = <&kp>, <&kp>;
     };
   };
+
   keymap {
     compatible = "zmk,keymap";
 

--- a/tests/specs/node_spacing.txt
+++ b/tests/specs/node_spacing.txt
@@ -1,0 +1,33 @@
+== empty line between nodes ==
+node1@1000 {
+  compatible = "dtsfmt";
+};
+node2@2000 {
+  compatible = "dtsfmt";
+};
+
+[expect]
+node1@1000 {
+  compatible = "dtsfmt";
+};
+
+node2@2000 {
+  compatible = "dtsfmt";
+};
+
+== empty line between nodes and properties ==
+node1@1000 {
+  compatible = "dtsfmt";
+  child@1000 {
+    compatible = "child";
+  };
+};
+
+[expect]
+node1@1000 {
+  compatible = "dtsfmt";
+
+  child@1000 {
+    compatible = "child";
+  };
+};


### PR DESCRIPTION
Previously, `dtsfmt` removed all the empty lines between nodes. So we always got 

```
node {
};
node {
};
node [
};
```

This can be difficult to read when there are a lot of nodes for larger devicetree files.

Comment https://github.com/mskelton/dtsfmt/issues/28#issuecomment-3204137436 mentions that we may want to space adjacent nodes like 

```
node {
};

node {
};
```

This change addresses that comment by placing a new line between adjacent nodes.

Test: added tests/specs/node_spacing.txt
