### PR TITLE
fix: Use absolute path when looking for the dtsfmtrc file.

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,10 @@ impl Config {
 }
 
 fn find_rc_file(path: &Path) -> Option<PathBuf> {
-    let mut path: PathBuf = path.into();
+    let mut path: PathBuf = std::path::absolute(path).unwrap_or_else(|_| {
+        eprintln!("Failed to get absolute path, fallback to original path");
+        path.to_path_buf()
+    });
     let file = Path::new(constants::RC_FILENAME);
 
     // Remove filename if it exists. This happens if the user specifies a path


### PR DESCRIPTION
Previously, `find_rc_file()` used the path provided by the CLI to locate the RC file. The path might be a relative path or an absolute path. It searched for RC_FILENAME and removed the parent, until finding file or the path being empty.

This could cause a problem for relative paths. For example, consider the following directory tree:

```
/home/
- dir1/
  - dir2/
    - .dtsfmtrc.toml
    - dir3/
      - devicetree.dts
```

If the user ran `dtsfmt` at `dir3` using `dtsfmt ./devicetree.dts`, `find_rc_file()` only looked for the .dtsfmtrc at `./` (dir3) and terminated because `./` has no parent.

This change fixes this behavior by always using the absolute path when finding the RC file.

Fixes #43
Test: Manually tested using the devicetree structure mentioned above.