### PR TITLE
fix: Implement Default trait for Config.

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,7 @@ use crate::layouts::KeyboardLayoutType;
 
 mod constants;
 
-#[derive(Default, Deserialize, TypedBuilder)]
+#[derive(Deserialize, TypedBuilder)]
 pub struct Config {
     #[builder(default)]
     #[serde(default)]
@@ -21,6 +21,12 @@ pub struct Config {
     #[builder(default)]
     #[serde(default)]
     pub warn_on_unhandled_tokens: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::builder().build()
+    }
 }
 
 impl Config {


### PR DESCRIPTION
Previously, Config derived its Default trait from all its fields. This made the `indent_str` initialized to `String::default()`, which is empty instead of `default_indent_str()`.

This change fixes the problem by implementing the Default trait using the TypedBuilder, which specifies the default value of each field in its `default_code` attribute.

Test: `dtsfmt ./devicetree.dts` (without .dtsfmtrc.toml), verified that the devicetree uses two spaces for indentation.