### PR TITLE
Support /plugin/ directives.

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -27,7 +27,7 @@ fn traverse(
     let kind = node.kind();
 
     match kind {
-        "file_version" => {
+        "file_version" | "plugin" => {
             writer.push_str(&format!("{}\n\n", get_text(source, cursor)));
         }
         "comment" => {

--- a/tests/specs/directives.txt
+++ b/tests/specs/directives.txt
@@ -1,0 +1,24 @@
+== document version ==
+/dts-v1/;
+
+/ {};
+
+[expect]
+/dts-v1/;
+
+/ {
+};
+
+== plugin ==
+/dts-v1/;
+/plugin/;
+
+/ {};
+
+[expect]
+/dts-v1/;
+
+/plugin/;
+
+/ {
+};


### PR DESCRIPTION
This change adds support for `/plugin/;` directives used by DTS overlays (https://docs.kernel.org/devicetree/overlay-notes.html).

```
/dts-v1/;
/plugin/;
&ocp {
  bar {
    compatible = "corp,bar";
  };
};
```

Test: Added directives.txt